### PR TITLE
Use libtiff typedef in TIFFSetDirectory

### DIFF
--- a/libtiff/tiff.go
+++ b/libtiff/tiff.go
@@ -52,7 +52,7 @@ func (t Tiff) Iter(cb func(int)) int {
 }
 
 func (t Tiff) SetDir(n int) error {
-	if int(C.TIFFSetDirectory(t.data, C.uint16(n))) != 1 {
+	if int(C.TIFFSetDirectory(t.data, C.tdir_t(n))) != 1 {
 		return errors.New("Invalid directory")
 	}
 	return nil


### PR DESCRIPTION
Updates TIFFSetDirectory to use tdir_t instead of uint_16.

libtiff 4.5.0 introduced a [breaking change](https://libtiff.gitlab.io/libtiff/releases/v4.5.0.html), changing that type to a unit_32. This caused go-libtiff to fail to compile on newer distros like Debian bookworm. Swapping to use the `tdir_t` here insulates this library and should allow it to work either pre- or post- that breaking change. 

